### PR TITLE
Use `crane.mkLib pkgs` instead of `crane.lib.${system}`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -34,8 +34,8 @@
     eachDefaultSystem
       (system:
         let
-          craneLib = crane.lib.${system};
           pkgs = nixpkgs.legacyPackages.${system};
+          craneLib = crane.mkLib pkgs;
           lib = pkgs.lib;
           version = "0.1.0";
         in


### PR DESCRIPTION
https://github.com/ipetkov/crane/blob/0081e9c447f3b70822c142908f08ceeb436982b8/CHANGELOG.md?plain=1#L87-L88